### PR TITLE
Agregar EP GetSkidsWtihDetails

### DIFF
--- a/Configurations/Databases/DatabaseTables/SkidConfiguration.cs
+++ b/Configurations/Databases/DatabaseTables/SkidConfiguration.cs
@@ -40,7 +40,8 @@ namespace skterminal_fuel_skids_api.Configurations.Databases.DatabaseTables
           Description = "Patín de Entrega",
           CreationDate = DateTimeOffset.Parse("2025-07-21 19:45:10.924489+00"),
           Enabled = true,
-          ProductId = Guid.Parse(DefaultProductsIds.ASFALTO)
+          ProductId = Guid.Parse(DefaultProductsIds.ASFALTO),
+          Order = 1
         },
         new Skid
         {
@@ -50,7 +51,8 @@ namespace skterminal_fuel_skids_api.Configurations.Databases.DatabaseTables
           Description = "Patín de Recepción",
           CreationDate = DateTimeOffset.Parse("2025-06-30 06:00:00+00"),
           Enabled = true,
-          ProductId = Guid.Parse(DefaultProductsIds.ASFALTO)
+          ProductId = Guid.Parse(DefaultProductsIds.ASFALTO),
+          Order = 2
         }
       );
     }

--- a/Configurations/Databases/DatabaseTables/TagConfiguration.cs
+++ b/Configurations/Databases/DatabaseTables/TagConfiguration.cs
@@ -79,7 +79,7 @@ namespace skterminal_fuel_skids_api.Configurations.Databases.DatabaseTables
           DataType = "Valores Generales",
           FloatingPrecision = 2,
           MeasurementUnit = "Kg/cm²",
-          Display = null,
+          Display = 0,
           Order = 4,
           Enabled = true,
           CreationDate = DateTimeOffset.UtcNow
@@ -144,7 +144,7 @@ namespace skterminal_fuel_skids_api.Configurations.Databases.DatabaseTables
           Enabled = true,
           CreationDate = DateTimeOffset.UtcNow
         }
-            );
+      );
     }
   }
 }

--- a/Configurations/Mapper/MapperConfiguration.cs
+++ b/Configurations/Mapper/MapperConfiguration.cs
@@ -9,12 +9,11 @@ namespace skterminal_fuel_skids_api.Configurations.Mapper
   {
     public MapperConfiguration()
     {
-      // Skid -> GetSkidDetailDto (las listas se rellenan en el servicio)
+   
       CreateMap<Skid, GetSkidDetailDto>()
-        .ForMember(d => d.ParameterTagList, opt => opt.Ignore())
+        .ForMember(d => d.ValoresGeneralesTagList, opt => opt.Ignore())
         .ForMember(d => d.OperationTagList, opt => opt.Ignore());
 
-      // Tag -> GetTagDetailDto
       CreateMap<Tag, GetTagDetailDto>();
     }
   }

--- a/Configurations/Mapper/MapperConfiguration.cs
+++ b/Configurations/Mapper/MapperConfiguration.cs
@@ -1,4 +1,7 @@
 ﻿using AutoMapper;
+using skterminal_fuel_skids_api.Dtos.SkidDtos;
+using skterminal_fuel_skids_api.Dtos.TagDtos;
+using skterminal_fuel_skids_api.Models;
 
 namespace skterminal_fuel_skids_api.Configurations.Mapper
 {
@@ -6,6 +9,13 @@ namespace skterminal_fuel_skids_api.Configurations.Mapper
   {
     public MapperConfiguration()
     {
+      // Skid -> GetSkidDetailDto (las listas se rellenan en el servicio)
+      CreateMap<Skid, GetSkidDetailDto>()
+        .ForMember(d => d.ParameterTagList, opt => opt.Ignore())
+        .ForMember(d => d.OperationTagList, opt => opt.Ignore());
+
+      // Tag -> GetTagDetailDto
+      CreateMap<Tag, GetTagDetailDto>();
     }
   }
 }

--- a/Configurations/Mapper/MapperConfiguration.cs
+++ b/Configurations/Mapper/MapperConfiguration.cs
@@ -11,7 +11,7 @@ namespace skterminal_fuel_skids_api.Configurations.Mapper
     {
    
       CreateMap<Skid, GetSkidDetailDto>()
-        .ForMember(d => d.ValoresGeneralesTagList, opt => opt.Ignore())
+        .ForMember(d => d.GeneralValuesTagList, opt => opt.Ignore())
         .ForMember(d => d.OperationTagList, opt => opt.Ignore());
 
       CreateMap<Tag, GetTagDetailDto>();

--- a/Controllers/SkidController.cs
+++ b/Controllers/SkidController.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using skterminal_fuel_skids_api.Configurations.CustomHttpResponses;
+using skterminal_fuel_skids_api.Dtos.SkidDtos;
+using skterminal_fuel_skids_api.Services.SkidServices;
+
+namespace skterminal_fuel_skids_api.Controllers
+{
+  [ApiController]
+  [Route("api/[controller]")]
+  public class SkidController : ControllerBase
+  {
+    private readonly ISkidService _skidService;
+
+    public SkidController(ISkidService skidService)
+    {
+      _skidService = skidService;
+    }
+
+    [HttpGet("GetSkidsWithDetails")]
+    [ProducesResponseType(typeof(IEnumerable<GetSkidDetailDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorMessage), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorMessage), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorMessage), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ErrorMessage), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<IEnumerable<GetSkidDetailDto>>> GetSkidsWithDetails()
+    {
+      var skids = await _skidService.GetSkidDetailsAsync();
+      return Ok(skids);
+    }
+  }
+}

--- a/Dtos/SkidDtos/GetSkidDetailDto.cs
+++ b/Dtos/SkidDtos/GetSkidDetailDto.cs
@@ -31,7 +31,7 @@ namespace skterminal_fuel_skids_api.Dtos.SkidDtos
    
     [JsonPropertyName("valoresGeneralesTagList")]
     [JsonPropertyOrder(1)]
-      public Dictionary<string, GetTagDetailDto> ValoresGeneralesTagList { get; set; } = new();
+      public Dictionary<string, GetTagDetailDto> GeneralValuesTagList { get; set; } = new();
 
     
     [JsonPropertyName("operationTagList")]

--- a/Dtos/SkidDtos/GetSkidDetailDto.cs
+++ b/Dtos/SkidDtos/GetSkidDetailDto.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel.DataAnnotations;
+using skterminal_fuel_skids_api.Dtos.TagDtos;
+
+namespace skterminal_fuel_skids_api.Dtos.SkidDtos
+{
+  public class GetSkidDetailDto
+  {
+    [Required]
+    public Guid Id { get; set; }
+
+    [Required]
+    [StringLength(50)]
+    public string Tag { get; set; } = null!;
+
+    [Required]
+    [StringLength(50)]
+    public string Hub { get; set; } = null!;
+
+    [StringLength(150)]
+    public string? Description { get; set; }
+
+    public int? Order { get; set; }
+
+    [Required]
+    public bool Enabled { get; set; }
+
+    [Required]
+    public DateTimeOffset CreationDate { get; set; }
+
+    public Dictionary<string, GetTagDetailDto> ParameterTagList { get; set; } = new();
+    public Dictionary<string, GetTagDetailDto> OperationTagList { get; set; } = new();
+  }
+}

--- a/Dtos/SkidDtos/GetSkidDetailDto.cs
+++ b/Dtos/SkidDtos/GetSkidDetailDto.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using skterminal_fuel_skids_api.Dtos.TagDtos;
 
 namespace skterminal_fuel_skids_api.Dtos.SkidDtos
@@ -27,7 +28,14 @@ namespace skterminal_fuel_skids_api.Dtos.SkidDtos
     [Required]
     public DateTimeOffset CreationDate { get; set; }
 
-    public Dictionary<string, GetTagDetailDto> ParameterTagList { get; set; } = new();
+   
+    [JsonPropertyName("valoresGeneralesTagList")]
+    [JsonPropertyOrder(1)]
+      public Dictionary<string, GetTagDetailDto> ValoresGeneralesTagList { get; set; } = new();
+
+    
+    [JsonPropertyName("operationTagList")]
+    [JsonPropertyOrder(2)]
     public Dictionary<string, GetTagDetailDto> OperationTagList { get; set; } = new();
   }
 }

--- a/Dtos/TagDtos/GetTagDetailDto.cs
+++ b/Dtos/TagDtos/GetTagDetailDto.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace skterminal_fuel_skids_api.Dtos.TagDtos
+{
+  public class GetTagDetailDto
+  {
+    [Required]
+    public Guid Id { get; set; }
+
+    [Required]
+    [StringLength(50)]
+    public string TagName { get; set; } = null!;
+
+    [StringLength(150)]
+    public string? Description { get; set; }
+
+    [StringLength(100)]
+    public string? MeasurementUnit { get; set; }
+
+    [Required]
+    public double FloatingPrecision { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string DataType { get; set; } = null!;
+
+    public int? Order { get; set; }
+
+    public int? Display { get; set; }
+
+    [Required]
+    public bool Enabled { get; set; }
+
+    [Required]
+    public DateTimeOffset CreationDate { get; set; }
+  }
+}

--- a/Migrations/20250930212436_1.0V_InitialMigration.Designer.cs
+++ b/Migrations/20250930212436_1.0V_InitialMigration.Designer.cs
@@ -12,7 +12,7 @@ using skterminal_fuel_skids_api.Configurations.Databases;
 namespace skterminal_fuel_skids_api.Migrations
 {
     [DbContext(typeof(DataContextEntityFramework))]
-    [Migration("20250930183350_1.0V_InitialMigration")]
+    [Migration("20250930212436_1.0V_InitialMigration")]
     partial class _10V_InitialMigration
     {
         /// <inheritdoc />
@@ -67,7 +67,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 617, DateTimeKind.Unspecified).AddTicks(2587), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 502, DateTimeKind.Unspecified).AddTicks(9705), new TimeSpan(0, 0, 0, 0, 0)),
                             Description = "Asfalto",
                             Enabled = true,
                             Name = "Asfalto",
@@ -76,7 +76,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("d078ae2f-73db-4ddc-b419-b2db4a900c73"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 617, DateTimeKind.Unspecified).AddTicks(2604), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 502, DateTimeKind.Unspecified).AddTicks(9726), new TimeSpan(0, 0, 0, 0, 0)),
                             Description = "Gasolio",
                             Enabled = true,
                             Name = "Gasolio",
@@ -135,6 +135,7 @@ namespace skterminal_fuel_skids_api.Migrations
                             Description = "Patín de Entrega",
                             Enabled = true,
                             Hub = "",
+                            Order = 1,
                             ProductId = new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"),
                             Tag = "PS"
                         },
@@ -145,6 +146,7 @@ namespace skterminal_fuel_skids_api.Migrations
                             Description = "Patín de Recepción",
                             Enabled = true,
                             Hub = "",
+                            Order = 2,
                             ProductId = new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"),
                             Tag = "PE"
                         });
@@ -515,7 +517,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("a7e7b6a7-7b3b-4f2b-9d12-2b8abdb70d01"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2484), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(3), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Valores Generales",
                             Display = 0,
                             Enabled = true,
@@ -527,7 +529,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("b8a6c5f2-3c44-4c7e-8a3a-5a1f6f0d2a02"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2488), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(8), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 1,
                             Enabled = true,
@@ -539,7 +541,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("c9b7d6e3-4d55-4d8f-9b4b-6b2f7f1e3b03"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2492), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(11), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 1,
                             Enabled = true,
@@ -551,8 +553,9 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("da08e7f4-5e66-4e90-ac5c-7c30802f4c04"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2495), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(15), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Valores Generales",
+                            Display = 0,
                             Enabled = true,
                             FloatingPrecision = 2.0,
                             MeasurementUnit = "Kg/cm²",
@@ -562,7 +565,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("eb19f805-6f77-4191-bd6d-8d4191405d05"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2499), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(19), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 0,
                             Enabled = true,
@@ -574,7 +577,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("fc2a0916-7088-4292-ce7e-9e52a2516e06"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2502), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(22), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 0,
                             Enabled = true,
@@ -586,7 +589,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("0d3b1a27-8199-4393-df8f-af63b3627f07"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2505), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(26), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Valores Generales",
                             Display = 0,
                             Enabled = true,
@@ -598,7 +601,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("1e4c2b38-92aa-44a4-e090-b074c4738008"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2513), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(34), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 0,
                             Enabled = true,
@@ -610,7 +613,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("2f5d3c49-a3bb-45b5-f1a1-c185d5849109"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2516), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(37), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 0,
                             Enabled = true,

--- a/Migrations/20250930212436_1.0V_InitialMigration.cs
+++ b/Migrations/20250930212436_1.0V_InitialMigration.cs
@@ -249,8 +249,8 @@ namespace skterminal_fuel_skids_api.Migrations
                 columns: new[] { "Id", "CreationDate", "Description", "Enabled", "ModificationDate", "Name", "TagValue" },
                 values: new object[,]
                 {
-                    { new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 617, DateTimeKind.Unspecified).AddTicks(2587), new TimeSpan(0, 0, 0, 0, 0)), "Asfalto", true, null, "Asfalto", 1 },
-                    { new Guid("d078ae2f-73db-4ddc-b419-b2db4a900c73"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 617, DateTimeKind.Unspecified).AddTicks(2604), new TimeSpan(0, 0, 0, 0, 0)), "Gasolio", true, null, "Gasolio", 2 }
+                    { new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 502, DateTimeKind.Unspecified).AddTicks(9705), new TimeSpan(0, 0, 0, 0, 0)), "Asfalto", true, null, "Asfalto", 1 },
+                    { new Guid("d078ae2f-73db-4ddc-b419-b2db4a900c73"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 502, DateTimeKind.Unspecified).AddTicks(9726), new TimeSpan(0, 0, 0, 0, 0)), "Gasolio", true, null, "Gasolio", 2 }
                 });
 
             migrationBuilder.InsertData(
@@ -259,15 +259,15 @@ namespace skterminal_fuel_skids_api.Migrations
                 columns: new[] { "Id", "CreationDate", "DataType", "Description", "Display", "Enabled", "FloatingPrecision", "MeasurementUnit", "Order", "TagName" },
                 values: new object[,]
                 {
-                    { new Guid("0d3b1a27-8199-4393-df8f-af63b3627f07"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2505), new TimeSpan(0, 0, 0, 0, 0)), "Valores Generales", null, 0, true, 2.0, "°C", 7, "TEMP_DENS" },
-                    { new Guid("1e4c2b38-92aa-44a4-e090-b074c4738008"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2513), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 0, true, 2.0, "°C", 8, "TEMP_TREN1" },
-                    { new Guid("2f5d3c49-a3bb-45b5-f1a1-c185d5849109"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2516), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 0, true, 2.0, "°C", 9, "TEMP_TREN2" },
-                    { new Guid("a7e7b6a7-7b3b-4f2b-9d12-2b8abdb70d01"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2484), new TimeSpan(0, 0, 0, 0, 0)), "Valores Generales", null, 0, true, 2.0, "Kg/m³", 1, "DENSIDAD" },
-                    { new Guid("b8a6c5f2-3c44-4c7e-8a3a-5a1f6f0d2a02"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2488), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 1, true, 2.0, "L/m", 2, "FLUJO_TREN1" },
-                    { new Guid("c9b7d6e3-4d55-4d8f-9b4b-6b2f7f1e3b03"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2492), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 1, true, 2.0, "L/m", 3, "FLUJO_TREN2" },
-                    { new Guid("da08e7f4-5e66-4e90-ac5c-7c30802f4c04"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2495), new TimeSpan(0, 0, 0, 0, 0)), "Valores Generales", null, null, true, 2.0, "Kg/cm²", 4, "PRESION_DENS" },
-                    { new Guid("eb19f805-6f77-4191-bd6d-8d4191405d05"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2499), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 0, true, 2.0, "Kg/cm²", 5, "PRESION_TREN1" },
-                    { new Guid("fc2a0916-7088-4292-ce7e-9e52a2516e06"), new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2502), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 0, true, 2.0, "Kg/cm²", 6, "PRESION_TREN2" }
+                    { new Guid("0d3b1a27-8199-4393-df8f-af63b3627f07"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(26), new TimeSpan(0, 0, 0, 0, 0)), "Valores Generales", null, 0, true, 2.0, "°C", 7, "TEMP_DENS" },
+                    { new Guid("1e4c2b38-92aa-44a4-e090-b074c4738008"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(34), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 0, true, 2.0, "°C", 8, "TEMP_TREN1" },
+                    { new Guid("2f5d3c49-a3bb-45b5-f1a1-c185d5849109"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(37), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 0, true, 2.0, "°C", 9, "TEMP_TREN2" },
+                    { new Guid("a7e7b6a7-7b3b-4f2b-9d12-2b8abdb70d01"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(3), new TimeSpan(0, 0, 0, 0, 0)), "Valores Generales", null, 0, true, 2.0, "Kg/m³", 1, "DENSIDAD" },
+                    { new Guid("b8a6c5f2-3c44-4c7e-8a3a-5a1f6f0d2a02"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(8), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 1, true, 2.0, "L/m", 2, "FLUJO_TREN1" },
+                    { new Guid("c9b7d6e3-4d55-4d8f-9b4b-6b2f7f1e3b03"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(11), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 1, true, 2.0, "L/m", 3, "FLUJO_TREN2" },
+                    { new Guid("da08e7f4-5e66-4e90-ac5c-7c30802f4c04"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(15), new TimeSpan(0, 0, 0, 0, 0)), "Valores Generales", null, 0, true, 2.0, "Kg/cm²", 4, "PRESION_DENS" },
+                    { new Guid("eb19f805-6f77-4191-bd6d-8d4191405d05"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(19), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 0, true, 2.0, "Kg/cm²", 5, "PRESION_TREN1" },
+                    { new Guid("fc2a0916-7088-4292-ce7e-9e52a2516e06"), new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(22), new TimeSpan(0, 0, 0, 0, 0)), "Parámetro de operación", null, 0, true, 2.0, "Kg/cm²", 6, "PRESION_TREN2" }
                 });
 
             migrationBuilder.InsertData(
@@ -276,8 +276,8 @@ namespace skterminal_fuel_skids_api.Migrations
                 columns: new[] { "Id", "CreationDate", "Description", "Enabled", "Hub", "Order", "ProductId", "Tag" },
                 values: new object[,]
                 {
-                    { new Guid("32368847-78ab-4bf7-ab01-5ae54f957340"), new DateTimeOffset(new DateTime(2025, 7, 21, 19, 45, 10, 924, DateTimeKind.Unspecified).AddTicks(4890), new TimeSpan(0, 0, 0, 0, 0)), "Patín de Entrega", true, "", null, new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"), "PS" },
-                    { new Guid("3e18ebd2-b998-4e52-96ff-e2d7975ead73"), new DateTimeOffset(new DateTime(2025, 6, 30, 6, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "Patín de Recepción", true, "", null, new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"), "PE" }
+                    { new Guid("32368847-78ab-4bf7-ab01-5ae54f957340"), new DateTimeOffset(new DateTime(2025, 7, 21, 19, 45, 10, 924, DateTimeKind.Unspecified).AddTicks(4890), new TimeSpan(0, 0, 0, 0, 0)), "Patín de Entrega", true, "", 1, new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"), "PS" },
+                    { new Guid("3e18ebd2-b998-4e52-96ff-e2d7975ead73"), new DateTimeOffset(new DateTime(2025, 6, 30, 6, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "Patín de Recepción", true, "", 2, new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"), "PE" }
                 });
 
             migrationBuilder.InsertData(

--- a/Migrations/DataContextEntityFrameworkModelSnapshot.cs
+++ b/Migrations/DataContextEntityFrameworkModelSnapshot.cs
@@ -64,7 +64,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 617, DateTimeKind.Unspecified).AddTicks(2587), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 502, DateTimeKind.Unspecified).AddTicks(9705), new TimeSpan(0, 0, 0, 0, 0)),
                             Description = "Asfalto",
                             Enabled = true,
                             Name = "Asfalto",
@@ -73,7 +73,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("d078ae2f-73db-4ddc-b419-b2db4a900c73"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 617, DateTimeKind.Unspecified).AddTicks(2604), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 502, DateTimeKind.Unspecified).AddTicks(9726), new TimeSpan(0, 0, 0, 0, 0)),
                             Description = "Gasolio",
                             Enabled = true,
                             Name = "Gasolio",
@@ -132,6 +132,7 @@ namespace skterminal_fuel_skids_api.Migrations
                             Description = "Patín de Entrega",
                             Enabled = true,
                             Hub = "",
+                            Order = 1,
                             ProductId = new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"),
                             Tag = "PS"
                         },
@@ -142,6 +143,7 @@ namespace skterminal_fuel_skids_api.Migrations
                             Description = "Patín de Recepción",
                             Enabled = true,
                             Hub = "",
+                            Order = 2,
                             ProductId = new Guid("7e1fce1f-f758-404c-9ab2-cda5f5115529"),
                             Tag = "PE"
                         });
@@ -512,7 +514,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("a7e7b6a7-7b3b-4f2b-9d12-2b8abdb70d01"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2484), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(3), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Valores Generales",
                             Display = 0,
                             Enabled = true,
@@ -524,7 +526,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("b8a6c5f2-3c44-4c7e-8a3a-5a1f6f0d2a02"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2488), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(8), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 1,
                             Enabled = true,
@@ -536,7 +538,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("c9b7d6e3-4d55-4d8f-9b4b-6b2f7f1e3b03"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2492), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(11), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 1,
                             Enabled = true,
@@ -548,8 +550,9 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("da08e7f4-5e66-4e90-ac5c-7c30802f4c04"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2495), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(15), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Valores Generales",
+                            Display = 0,
                             Enabled = true,
                             FloatingPrecision = 2.0,
                             MeasurementUnit = "Kg/cm²",
@@ -559,7 +562,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("eb19f805-6f77-4191-bd6d-8d4191405d05"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2499), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(19), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 0,
                             Enabled = true,
@@ -571,7 +574,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("fc2a0916-7088-4292-ce7e-9e52a2516e06"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2502), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(22), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 0,
                             Enabled = true,
@@ -583,7 +586,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("0d3b1a27-8199-4393-df8f-af63b3627f07"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2505), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(26), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Valores Generales",
                             Display = 0,
                             Enabled = true,
@@ -595,7 +598,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("1e4c2b38-92aa-44a4-e090-b074c4738008"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2513), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(34), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 0,
                             Enabled = true,
@@ -607,7 +610,7 @@ namespace skterminal_fuel_skids_api.Migrations
                         new
                         {
                             Id = new Guid("2f5d3c49-a3bb-45b5-f1a1-c185d5849109"),
-                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 18, 33, 49, 618, DateTimeKind.Unspecified).AddTicks(2516), new TimeSpan(0, 0, 0, 0, 0)),
+                            CreationDate = new DateTimeOffset(new DateTime(2025, 9, 30, 21, 24, 35, 504, DateTimeKind.Unspecified).AddTicks(37), new TimeSpan(0, 0, 0, 0, 0)),
                             DataType = "Parámetro de operación",
                             Display = 0,
                             Enabled = true,

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,9 @@ using skterminal_fuel_skids_api.Configurations.Controllers;
 using skterminal_fuel_skids_api.Configurations.CustomHttpResponses;
 using skterminal_fuel_skids_api.Configurations.Databases;
 using skterminal_fuel_skids_api.Repositories.GenericContract;
+using skterminal_fuel_skids_api.Repositories.SkidContract;
+using skterminal_fuel_skids_api.Services.SkidServices;
+using skterminal_fuel_skids_api.Validators.SkidValidators;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -84,6 +87,10 @@ builder.Services.AddSwaggerGen(c =>
 #endregion
 
 builder.Services.AddHttpClient();
+
+builder.Services.AddScoped<ISkidRepository, SkidRepository>();
+builder.Services.AddScoped<ISkidValidator, SkidValidator>();
+builder.Services.AddScoped<ISkidService, SkidService>();
 
 #region Allows to Inject as dependency
 #region Generic

--- a/Repositories/SkidContract/ISkidRepository.cs
+++ b/Repositories/SkidContract/ISkidRepository.cs
@@ -1,0 +1,11 @@
+﻿using skterminal_fuel_skids_api.Models;
+using skterminal_fuel_skids_api.Repositories.GenericContract;
+
+namespace skterminal_fuel_skids_api.Repositories.SkidContract
+{
+  public interface ISkidRepository : IGenericRepository<Skid>
+  {
+    Task<IEnumerable<Skid>> GetAllSkidsWithTagsAsync();
+    Task<bool> IsThereAnotherSkid(string skidTag);
+  }
+}

--- a/Repositories/SkidContract/SkidRepository.cs
+++ b/Repositories/SkidContract/SkidRepository.cs
@@ -1,0 +1,53 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using skterminal_fuel_skids_api.Configurations.Databases;
+using skterminal_fuel_skids_api.Models;
+using skterminal_fuel_skids_api.Repositories.GenericContract;
+
+namespace skterminal_fuel_skids_api.Repositories.SkidContract
+{
+  public class SkidRepository : GenericRepository<Skid>, ISkidRepository
+  {
+    private readonly DataContextEntityFramework _contextEntityFramework;
+    private readonly IMapper _mapper;
+
+    public SkidRepository(DataContextEntityFramework contextEntityFramework, IMapper mapper)
+      : base(contextEntityFramework, mapper)
+    {
+      _contextEntityFramework = contextEntityFramework;
+      _mapper = mapper;
+    }
+
+    public async Task<IEnumerable<Skid>> GetAllSkidsWithTagsAsync()
+    {
+      var skids = await _contextEntityFramework.Skids
+        .Include(s => s.SkidTagsList)
+          .ThenInclude(st => st.Tags)
+        .AsNoTracking()
+        .OrderByDescending(s => s.Order)
+        .ToListAsync();
+
+      foreach (var skid in skids)
+      {
+        skid.SkidTagsList = skid.SkidTagsList?
+          .OrderBy(st => st.Tags.Order)
+          .ToList();
+      }
+
+      return skids;
+    }
+
+    public async Task<bool> IsThereAnotherSkid(string skidTag)
+    {
+      try
+      {
+        return await _contextEntityFramework.Skids
+          .AnyAsync(s => s.Tag.Equals(skidTag) && s.Enabled == true);
+      }
+      catch (Exception ex)
+      {
+        throw new InvalidOperationException($"Error al verificar si existe otro skid con tag: {skidTag}", ex);
+      }
+    }
+  }
+}

--- a/Services/SkidServices/ISkidService.cs
+++ b/Services/SkidServices/ISkidService.cs
@@ -1,0 +1,9 @@
+﻿using skterminal_fuel_skids_api.Dtos.SkidDtos;
+
+namespace skterminal_fuel_skids_api.Services.SkidServices
+{
+  public interface ISkidService
+  {
+    Task<IEnumerable<GetSkidDetailDto>> GetSkidDetailsAsync();
+  }
+}

--- a/Services/SkidServices/SkidService.cs
+++ b/Services/SkidServices/SkidService.cs
@@ -64,7 +64,7 @@ namespace skterminal_fuel_skids_api.Services.SkidServices
             var key = t.TagName; 
 
             if (t.DataType == "Valores Generales")
-              dto.ValoresGeneralesTagList[key] = tagDto;
+              dto.GeneralValuesTagList[key] = tagDto;
             else if (t.DataType == "Parámetro de operación")
               dto.OperationTagList[key] = tagDto;
             else

--- a/Services/SkidServices/SkidService.cs
+++ b/Services/SkidServices/SkidService.cs
@@ -1,0 +1,81 @@
+﻿using AutoMapper;
+using skterminal_fuel_skids_api.Dtos.SkidDtos;
+using skterminal_fuel_skids_api.Dtos.TagDtos;
+using skterminal_fuel_skids_api.Repositories.SkidContract;
+using skterminal_fuel_skids_api.Validators.SkidValidators;
+
+namespace skterminal_fuel_skids_api.Services.SkidServices
+{
+  public class SkidService : ISkidService
+  {
+    private readonly ISkidRepository _skidRepository;
+    private readonly ISkidValidator _skidValidator;
+    private readonly IMapper _mapper;
+
+    public SkidService(ISkidRepository skidRepository, ISkidValidator skidValidator, IMapper mapper)
+    {
+      _skidRepository = skidRepository;
+      _skidValidator = skidValidator;
+      _mapper = mapper;
+    }
+
+    public async Task<IEnumerable<GetSkidDetailDto>> GetSkidDetailsAsync()
+    {
+      // Traer skids con sus tags
+      var skids = await _skidRepository.GetAllSkidsWithTagsAsync();
+
+      // Validar resultado
+      _skidValidator.IsSkidWithDetailsListValid(skids);
+
+      // Proyectar a DTO
+      var result = skids.Select(s =>
+      {
+        var dto = new GetSkidDetailDto
+        {
+          Id = s.Id,
+          Tag = s.Tag,
+          Hub = s.Hub,
+          Description = s.Description,
+          Order = s.Order,
+          Enabled = s.Enabled,
+          CreationDate = s.CreationDate
+        };
+
+        var skidTags = s.SkidTagsList?
+          .Where(st => st?.Tags != null)
+          .OrderBy(st => st!.Tags.Order);
+
+        if (skidTags != null)
+        {
+          foreach (var st in skidTags)
+          {
+            var t = st!.Tags!;
+            var tagDto = new GetTagDetailDto
+            {
+              Id = t.Id,
+              TagName = t.TagName,
+              Description = t.Description,
+              MeasurementUnit = t.MeasurementUnit,
+              FloatingPrecision = t.FloatingPrecision,
+              DataType = t.DataType,
+              Order = t.Order,
+              Display = t.Display,
+              Enabled = t.Enabled,
+              CreationDate = t.CreationDate
+            };
+
+            var key = t.TagName; // usa t.Id.ToString() si quieres evitar colisiones por nombre
+            if (t.Display == 1)
+              dto.OperationTagList[key] = tagDto;
+            else
+              dto.ParameterTagList[key] = tagDto;
+          }
+        }
+
+        return dto;
+      }).ToList();
+
+      return result;
+    }
+  }
+}

--- a/Services/SkidServices/SkidService.cs
+++ b/Services/SkidServices/SkidService.cs
@@ -21,13 +21,9 @@ namespace skterminal_fuel_skids_api.Services.SkidServices
 
     public async Task<IEnumerable<GetSkidDetailDto>> GetSkidDetailsAsync()
     {
-      // Traer skids con sus tags
       var skids = await _skidRepository.GetAllSkidsWithTagsAsync();
-
-      // Validar resultado
       _skidValidator.IsSkidWithDetailsListValid(skids);
 
-      // Proyectar a DTO
       var result = skids.Select(s =>
       {
         var dto = new GetSkidDetailDto
@@ -41,15 +37,16 @@ namespace skterminal_fuel_skids_api.Services.SkidServices
           CreationDate = s.CreationDate
         };
 
-        var skidTags = s.SkidTagsList?
+        var tags = s.SkidTagsList?
           .Where(st => st?.Tags != null)
-          .OrderBy(st => st!.Tags.Order);
+          .Select(st => st!.Tags!)
+          .OrderBy(t => t.Order ?? int.MaxValue)
+          .ToList();
 
-        if (skidTags != null)
+        if (tags != null)
         {
-          foreach (var st in skidTags)
+          foreach (var t in tags)
           {
-            var t = st!.Tags!;
             var tagDto = new GetTagDetailDto
             {
               Id = t.Id,
@@ -64,11 +61,14 @@ namespace skterminal_fuel_skids_api.Services.SkidServices
               CreationDate = t.CreationDate
             };
 
-            var key = t.TagName; // usa t.Id.ToString() si quieres evitar colisiones por nombre
-            if (t.Display == 1)
+            var key = t.TagName; 
+
+            if (t.DataType == "Valores Generales")
+              dto.ValoresGeneralesTagList[key] = tagDto;
+            else if (t.DataType == "Parámetro de operación")
               dto.OperationTagList[key] = tagDto;
             else
-              dto.ParameterTagList[key] = tagDto;
+              dto.OperationTagList[key] = tagDto;
           }
         }
 

--- a/Validators/SkidValidators/ISkidValidator.cs
+++ b/Validators/SkidValidators/ISkidValidator.cs
@@ -1,0 +1,10 @@
+﻿using skterminal_fuel_skids_api.Models;
+
+namespace skterminal_fuel_skids_api.Validators.SkidValidators
+{
+  public interface ISkidValidator
+  {
+    bool IsSkidWithDetailsListValid(IEnumerable<Skid>? skids);
+    void IsAddSkidValid(bool skidAlreadyExists);
+  }
+}

--- a/Validators/SkidValidators/SkidValidator.cs
+++ b/Validators/SkidValidators/SkidValidator.cs
@@ -1,0 +1,23 @@
+﻿using skterminal_fuel_skids_api.Configurations.CustomHttpResponses;
+using skterminal_fuel_skids_api.Models;
+using skterminal_fuel_skids_api.Utils.Validations;
+
+namespace skterminal_fuel_skids_api.Validators.SkidValidators
+{
+  public class SkidValidator : ISkidValidator
+  {
+    public bool IsSkidWithDetailsListValid(IEnumerable<Skid>? skids)
+    {
+      if (!skids.IsDifferentToNull() || !skids!.Any())
+        throw new NotFoundException("No se encontró ningún skid.");
+
+      return true;
+    }
+
+    public void IsAddSkidValid(bool skidAlreadyExists)
+    {
+      if (skidAlreadyExists)
+        throw new BadRequestException("Ya existe un skid con ese tag.");
+    }
+  }
+}

--- a/skterminal-fuel-skids-api.csproj
+++ b/skterminal-fuel-skids-api.csproj
@@ -27,11 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="Controllers\" />
-      <Folder Include="Dtos\" />
       <Folder Include="Migrations\" />
-      <Folder Include="Validators\" />
-      <Folder Include="Services\" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Descripción
_Agregue un EP GetSkidsWithDetails y se agregaron Campos faltantes (order) en el dato semilla de Skid
_
<img width="1877" height="1035" alt="image" src="https://github.com/user-attachments/assets/386b8578-cff0-4580-ad1b-d598472810a8" />


---
# Checklist de código para proyectos backend C#
## 1. **[Aspectos a revisar de la PR]**

- [x] Los commits estan relacionados con los elementos del [WBS](http://3.130.180.74/SoftwareDev/skterminal/wbs).
- [x] Se ha solicitado la revisión a al menos otro miembro del equipo así como haber agregado la etiqueta `Para revisión`.

## 2. ⚙️ **[Estilo]**

**Nomeclatura y nombres**:
- [x] Usa **camelCase** para variables locales.
- [x] Usa **_camelCase** para variables privadas.
- [x] Usa el Inglés para nombrar variables, métodos, clases, parámetros y modelos.
- [x] Usa nombres descriptivos para variables, métodos, clases, parámetros y modelos.
- [x] Usa verbo como primer palabra en caso de ser necesario para variables, métodos, clases, parámetros y modelos.
- [x] Usa **SCREAMING_SNAKE_CASE** para nombrar constantes
- [x] Usa **PascalCase** para nombres de clases, métodos y propiedades de Modelos.
- [x] Usa **IPascalCase** para nombres de interfaces.


## 3. 🔍 **[Formato]**

- [x] Se usa indentación de **dos espacios**
- [x] Usa un espacio entre palabras clave y paréntesis, y también entre operadores.
- [x] Longitud de cada línea es de máximo 120 caracteres.
- [x] No uses llaves { } para bloques de una sola línea en estructuras de control (if, else, for, while, etc.)


## 4. 🚀 **[Convenciones]**

- [x] Se tiene un máximo de 2 niveles de anidación.
- [x] Bloques referentes a módulos están contenidos entre `#region` y `#endregion`
- [x] Comentarios simples utilizados con dos diagonales `//Comentario`
- [x] Comentarios más grandes utilizados en bloque  `/*Comentario*/`
- [x] Hay un espacio entre métodos y conceptos diferentes.
- [x] No hay códgio muerto (no código comentado)
- [x] Se usa un operador ternario en caso de tener dos posibles respuestas en lugar de un if.


## 5. 🧩 [Patrones]
- [x] Cada clase y método debe tener una única responsabilidad o razón de cambio. **Principios SOLID: S**
- [x] Usa y define correctamente Interfaces para los Servicios, Repositorios y Validators. **Principios SOLID: I**
- [x] Usa inyección de dependencia en lugar de instanciación para los Servicios, Repsotories y Validators. **Principios SOLID: D**
- [x] Usa correctamente el patrón Services.
- [x] Usa correctamente el patrón Repository.
- [x] Usa correctamente el patrón Validators.

---
**Versión**: 1.0
**Fecha de Aprobación**: [Fecha]
**Revisiones**:
- Versión 1.0: Plantilla original publicada el [Fecha].